### PR TITLE
API makes more sense this way

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ __300b__ with all dependencies, minified and gzipped
 
 
 Creates a style component with internal _tracker_.
-- Adds styles to the browser on the __first__ instance mount.
+- Adds styles to the browser after the __first__ instance mount.
 - Removes after the __last__ instance unmount.
 - Thus helps you deliver styles you need to the customer, and clean up later.
 - Is not server-side rendering compatible!
@@ -18,10 +18,10 @@ Creates a style component with internal _tracker_.
 ```js
 import {styleSingleton} from 'react-style-singleton'
 
-const Style = styleSingleton();
+const Style = styleSingleton('body {color:red}');
 
 export const App = () => (
-  <Style styles={'body {color:red}'} />
+  <Style />
 );
 ```
 
@@ -30,12 +30,12 @@ export const App = () => (
 ```js
 import {styleHookSingleton} from 'react-style-singleton';
 
-const useStyle = styleHookSingleton();
-const useAnotherStyle = styleHookSingleton();
+const useStyle = styleHookSingleton('div {color:red}');
+const useAnotherStyle = styleHookSingleton('body { background-color:red }');
 
 export const App = () => {
-  useStyle('div {color:red}');
-  useAnotherStyle('body { background-color:red }');
+  useStyle();
+  useAnotherStyle();
   return (<div />);
 }
 ```

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import {styleHookSingleton} from "./hook";
+import {styleHookSingleton} from './hook';
 
-type Props = { styles: string };
+type Props = {};
 
-export const styleSingleton = () => {
-  const useStyle = styleHookSingleton();
+export const styleSingleton = (styles: string) => {
+  const useStyle = styleHookSingleton(styles);
 
-  const Sheet: React.FC<Props> = ({styles}) => {
-    useStyle(styles);
+  const Sheet: React.FC<Props> = () => {
+    useStyle();
     return null;
   };
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,14 +1,12 @@
 import * as React from 'react';
-import {stylesheetSingleton} from "./singleton";
+import {stylesheetSingleton} from './singleton';
 
-export const styleHookSingleton = () => {
-  const sheet = stylesheetSingleton();
+export const styleHookSingleton = (styles) => {
+  const sheet = stylesheetSingleton(styles);
   return (styles: string) => {
     React.useEffect(() => {
-      sheet.add(styles);
-      return () => {
-        sheet.remove();
-      }
+      sheet.add();
+      return () => sheet.remove();
     }, [])
   }
 };

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -22,8 +22,8 @@ function insertStyleTag(tag: HTMLStyleElement) {
   head.appendChild(tag);
 }
 
-export const stylesheetSingleton = (): {
-  add: (style: string) => void,
+export const stylesheetSingleton = (style: string): {
+  add: () => void,
   remove: () => void,
 } => {
   let counter = 0;


### PR DESCRIPTION
And I have this code:

```js
import React from "react";

import { getUseStyle } from "./useStyle";

export const singletoneStyled = styles => {
  const useStyle = getUseStyle(styles);

  const get = (_, defaultAs, __) => defaultClass => {
    const component = React.memo(
      React.forwardRef(({ children, as = defaultAs, ...props }, ref) => {
        useStyle();
        return React.createElement(
          as,
          { ...props, className: defaultClass, ref },
          children
        );
      })
    );
    component.displayName = `${defaultClass}💅`;
    return component;
  };

  // browser support https://caniuse.com/#search=proxy
  return new Proxy({}, { get });
};
```

can be use like this

```js
const css = strings => strings[0];
const styled = singletoneStyled(css`
  .Center {
    display: flex;
    justify-content: center;
    align-items: center;
  }
`);
const Center = styled.div("Center");
```