### PR TITLE
Remove peer dependency warning for React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "ts-react-toolbox": "^0.2.2"
   },
   "peerDependencies": {
-    "react": ">16.8.0",
-    "@types/react": ">16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "@types/react": "^16.8.0 || ^17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "ts-react-toolbox": "^0.2.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "@types/react": "^16.8.0"
+    "react": ">16.8.0",
+    "@types/react": ">16.8.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
Now that react 17 is a thing, this library gives missing peer dependency warnings

```diff
- "react": "^16.8.0",
+ "react": ">16.8.0"
```

Given it works well with 16.8+, I replaced `^` with `>`. 

A more strict validation would be to add `< 18` as well because we don't know what the future holds. But for now, I feel confident about `>16.8.0`