### PR TITLE
Add support for Node Corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,6 @@
     "tabWidth": 2,
     "semi": true,
     "singleQuote": true
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
Node ships with Corepack, a "package manager manager". It works by reading `packageManager` entry in `package.json` and downloading required binaries transparently, on-the-fly. Therefore it ensures that all developers using Corepack run the same version of package manager:

- reducing changes for any incompatibilities that might be caused by different versions,
- making installation seamless - Yarn is installed transparently without any intervention, provided you have Corepack enabled
- making migration to e.g. modern Yarn or pnpm very easy, as developers don't need to take any further actions besides pulling the latest changes from origin

This PR does not break the repository for those using Yarn Classic (v1) installed using standalone installer, while adding an easy way to contribute for those who did not install it.