### PR TITLE
Make it work when using Portals to iframes or child windows

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { stylesheetSingleton } from './singleton';
+import { useCurrentWindow } from './windowProvider';
 
 /**
  * creates a style on demand
@@ -29,11 +30,13 @@ export const styleHookSingleton = (): StyleSingletonHook => {
   const sheet = stylesheetSingleton();
 
   return (styles, isDynamic) => {
+    const currentWindow = useCurrentWindow();
+
     React.useEffect(() => {
-      sheet.add(styles);
+      sheet.add(styles, currentWindow);
 
       return () => {
-        sheet.remove();
+        sheet.remove(currentWindow);
       };
     }, [styles && isDynamic]);
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export {styleSingleton} from './component'
 export {stylesheetSingleton} from './singleton';
 export {styleHookSingleton} from './hook';
+export {WindowProvider} from './windowProvider';

--- a/src/windowProvider.tsx
+++ b/src/windowProvider.tsx
@@ -1,0 +1,25 @@
+import { createContext, ReactNode, useContext } from 'react';
+import * as React from 'react';
+
+export interface WindowContextValue {
+  window: Window;
+}
+
+export const WindowContext = createContext<WindowContextValue>({
+  window: window,
+});
+
+export function useCurrentWindow(): Window {
+  const context = useContext(WindowContext);
+
+  return context.window;
+}
+
+export interface WindowProviderProps {
+  window: Window;
+  children: ReactNode;
+}
+
+export function WindowProvider({ window, children }: WindowProviderProps): JSX.Element {
+  return <WindowContext.Provider value={{ window }}>{children}</WindowContext.Provider>;
+}


### PR DESCRIPTION
This library is indirectly used by `@elastic/eui` and I'm trying to make it work when using React Portals that render into iframes or child windows via `window.open` API.

This PR makes the library current window aware but at the same time shouldn't break the backwards compatibility.

To provide custom window context, `<WindowProvider>` is going to be used by the client to provide different window object.

Otherwise, when not used, the library should work as usual using the default window.