### PR TITLE
feat: add react v19 to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "react-dom": "^16.8.6"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "*",
+    "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
Thanks a lot for this package

I get the following warning from pnpm after upgrading to NextJS v15 (released today), which installs react 19 RC

React 19 is technically still in RC stage, but since a stable version of a major Metaframework is installing it, it's a sign that it's ready for production use and will now be used by many projects.

```ts
│ ├─┬ react-remove-scroll 2.6.0
│ │ ├── ✕ unmet peer react@"^16.8.0 || ^17.0.0 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
│ │ ├─┬ use-callback-ref 1.3.2
│ │ │ └── ✕ unmet peer react@"^16.8.0 || ^17.0.0 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
│ │ ├─┬ use-sidecar 1.1.2
│ │ │ └── ✕ unmet peer react@"^16.8.0 || ^17.0.0 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
│ │ └─┬ react-remove-scroll-bar 2.3.6
│ │   ├── ✕ unmet peer react@"^16.8.0 || ^17.0.0 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
│ │   └─┬ react-style-singleton 2.2.1
│ │     └── ✕ unmet peer react@"^16.8.0 || ^17.0.0 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
```
